### PR TITLE
✨ Add `evm_asm_vec` & `evm_asm` macros

### DIFF
--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -3,7 +3,7 @@ use crate::utils::debug_as_display;
 use hex;
 use std::fmt;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RefRepr {
     Pushed,
     Literal,
@@ -22,7 +22,7 @@ impl RefRepr {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RefType {
     Direct(usize),
     Delta(usize, usize),
@@ -37,20 +37,20 @@ impl fmt::Display for RefType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum PadSide {
     Front,
     Back,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MarkRef {
     pub size: Option<usize>,
     pub ref_type: RefType,
     pub ref_repr: RefRepr,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Asm {
     Op(Opcode),
     Data(Vec<u8>),
@@ -202,4 +202,137 @@ macro_rules! data {
         use hex_literal::hex;
         Asm::Data(hex!($bytes).into())
     }};
+}
+
+/// A shorthand for the [evm_asm_vec] macro, see its documentation for more details.
+#[macro_export]
+macro_rules! evm_asm {
+    // Capture everything into a tuple and forward it to the internal handler
+    ($($tt:tt)*) => {{
+        let mut result = Vec::new();
+        evm_asm_vec!(result; $($tt)*);
+        result
+    }};
+}
+
+/// A macro for filling a [Vec] with EVM [Asm] instruction variants.
+///
+/// Rules:
+/// - Shorthands for all [Asm] variants are supported directly. In order of precedence:
+///     - `Mark($expr)` -> `Asm::Mark($expr)`
+///     - `Data($expr)` -> `Asm::Data($expr)`
+///     - `PaddedBlock { $a:expr, $b:expr, $c:expr, $d: expr }` -> `Asm::PaddedBlock { size: $a, padding: $b, blocks: $c, side: $d }`
+///     - `Ref($expr)` -> `Asm::Ref($expr)`
+///     - `Op($expr)` -> `Asm::Op($expr)`
+///     - `Asm::$variant($($expr:expr),*)` -> `Asm::$variant($($expr),*)`
+///     - `VAR $var:ident` -> `$var`
+///     - `$head:expr` -> `Asm::Op($head)`
+///
+/// **Example**
+/// ```rust
+/// use evm_glue::{assembly::{*, Asm::*}, opcodes::{*, Opcode::*}, utils::*, evm_asm, evm_asm_vec};
+/// use hex_literal::hex;
+///
+/// let mut runtime_marks = MarkTracker::new();
+/// let empty_revert = runtime_marks.next();
+///
+/// let push0_var = Asm::Op(PUSH0);
+/// let runtime = vec![
+///     // Load x, y
+///     push0_var.clone(),
+///     Asm::Op(CALLDATALOAD),   // x
+///     Asm::Op(PUSH1(hex!("20"))),
+///     Asm::Op(CALLDATALOAD),   // x, y
+///     // Add and check for overflow
+///     Asm::Op(DUP2),           // x, y, x
+///     Asm::Op(ADD),            // x, r
+///     Asm::Op(DUP1),           // x, r, r
+///     Asm::Op(SWAP2),          // r, r, x
+///     Asm::Op(GT),             // r, x > r
+///     Asm::mref(empty_revert), // r, x > r, l
+///     Asm::Op(JUMPI),          // r
+///     // Return result.
+///     Asm::Op(MSIZE),
+///     Asm::Op(MSTORE),
+///     Asm::Op(MSIZE),
+///     Asm::Op(PUSH0),
+///     Asm::Op(RETURN),
+///     // Revert
+///     Asm::Mark(empty_revert),
+///     Asm::Op(JUMPDEST),
+///     Asm::Op(PUSH0),
+///     Asm::Op(PUSH0),
+///     Asm::Op(REVERT),
+/// ];
+/// let runtime_macro = evm_asm!(
+///     // Load x, y
+///     VAR push0_var,
+///     CALLDATALOAD,
+///     PUSH1(hex!("20")),
+///     CALLDATALOAD,            // x, y
+///     // Add and check for overflow
+///     DUP2,                    // x, y, x    
+///     ADD,                     // x, r       
+///     DUP1,                    // x, r, r    
+///     SWAP2,                   // r, r, x    
+///     GT,                      // r, x > r   
+///     Asm::mref(empty_revert), // r, x > r, l
+///     JUMPI,                   // r          
+///     // Return result.
+///     MSIZE,
+///     MSTORE,
+///     MSIZE,
+///     PUSH0,
+///     RETURN,
+///     // Revert
+///     Mark(empty_revert),
+///     JUMPDEST,
+///     PUSH0,
+///     PUSH0,
+///     REVERT,
+/// );
+/// assert_eq!(runtime_macro, runtime);
+/// ```
+#[macro_export]
+macro_rules! evm_asm_vec {
+    // Non-opcode variant matchers take precedent
+    ($res:ident; Mark($expr:expr) $(, $($rest:tt)*)?) => {
+        $res.push(Asm::Mark($expr));
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    ($res:ident; Data($expr:expr) $(, $($rest:tt)*)?) => {
+        $res.push(data!($expr));
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    ($res:ident; PaddedBlock { $a:expr, $b:expr, $c:expr, $d: expr } $(, $($rest:tt)*)?) => {
+        $res.push(Asm::PaddedBlock { size: $a, padding: $b, blocks: $c, side: $d });
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    ($res:ident; Ref($expr:expr) $(, $($rest:tt)*)?) => {
+        $res.push(Ref($expr));
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    ($res:ident; Op($expr:expr) $(, $($rest:tt)*)?) => {
+        $res.push(Op($expr));
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    // Match any qualified Asm variants
+    ($res:ident; Asm::$variant:ident($($expr:expr),*) $(, $($rest:tt)*)?) => {
+        $res.push(Asm::$variant($($expr),*));
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    // Allow for passing in var idents.
+    ($res:ident; VAR $var:ident $(, $($rest:tt)*)?) => {
+        $res.push($var);
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    // Assume anything else is an opcode
+    ($res:ident; $head:expr $(, $($rest:tt)*)?) => {
+        // TODO: Could further pattern match to allow for ambiguous functions / other types of
+        // exprs.
+        $res.push(Op($head));
+        evm_asm_vec!($res; $($($rest)*)?);
+    };
+    // Terminal case: all tokens have been consumed
+    ($res:ident;) => {};
 }

--- a/src/assembly.rs
+++ b/src/assembly.rs
@@ -267,7 +267,7 @@ macro_rules! evm_asm {
 /// let runtime_macro = evm_asm!(
 ///     // Load x, y
 ///     VAR push0_var,
-///     CALLDATALOAD,
+///     CALLDATALOAD,            // x
 ///     PUSH1(hex!("20")),
 ///     CALLDATALOAD,            // x, y
 ///     // Add and check for overflow
@@ -300,8 +300,8 @@ macro_rules! evm_asm_vec {
         $res.push(Asm::Mark($expr));
         evm_asm_vec!($res; $($($rest)*)?);
     };
-    ($res:ident; Data($expr:expr) $(, $($rest:tt)*)?) => {
-        $res.push(data!($expr));
+    ($res:ident; Data($lit:literal) $(, $($rest:tt)*)?) => {
+        $res.push(data!($lit));
         evm_asm_vec!($res; $($($rest)*)?);
     };
     ($res:ident; PaddedBlock { $a:expr, $b:expr, $c:expr, $d: expr } $(, $($rest:tt)*)?) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
+#![doc = include_str!("../README.md")]
+
 pub mod assembler;
+pub use assembler::{assemble_full, validate_asm, AssembleError, AssembleResult};
+
 pub mod assembly;
 pub mod opcodes;
 pub mod utils;


### PR DESCRIPTION
## Overview

Adds two new macros, `evm_asm_vec` & `evm_asm`, which shorthand the process of creating a `Vec` with `Asm` variants in it.

**Example**
```rs
use evm_glue::{assembly::{*, Asm::*}, opcodes::{*, Opcode::*}, utils::*, evm_asm, evm_asm_vec};
use hex_literal::hex;

let mut runtime_marks = MarkTracker::new();
let empty_revert = runtime_marks.next();
let push0_var = Asm::Op(PUSH0);

let runtime_macro = evm_asm!(
    // Load x, y
    VAR push0_var,
    CALLDATALOAD,            // x
    PUSH1(hex!("20")),
    CALLDATALOAD,            // x, y
    // Add and check for overflow
    DUP2,                    // x, y, x    
    ADD,                     // x, r       
    DUP1,                    // x, r, r    
    SWAP2,                   // r, r, x    
    GT,                      // r, x > r   
    Asm::mref(empty_revert), // r, x > r, l
    JUMPI,                   // r          
    // Return result.
    MSIZE,
    MSTORE,
    MSIZE,
    PUSH0,
    RETURN,
    // Revert
    Mark(empty_revert),
    JUMPDEST,
    PUSH0,
    PUSH0,
    REVERT,
);
```

also fixes doctests